### PR TITLE
add blob: to cspSources

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {},
   "license": "MIT",
   "ahaExtension": {
-    "cspSources": ["https://cdn.skypack.dev/"],
+    "cspSources": ["https://cdn.skypack.dev/", "blob:"],
     "contributes": {
       "commands": {
         "confetti": {


### PR DESCRIPTION
This is already present in the version of confettiExtension that comes preloaded in a trial account. However if this is manually installed without blob:, we see the following CSP error


```
Refused to create a worker from 'blob:[...] because it violates the following Content Security Policy directive: "script-src ...  ". Note that 'worker-src' was not explicitly set, so 'script-src' is used as a fallback.
```

the confetti code seems to gracefully function even despite failing to create the worker. But it would still be nice to avoid the error in the first place. 